### PR TITLE
fix: close #4 config.kit.target is no longer required, and should be …

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,9 +12,6 @@ export default {
     // specifying a different adapter
     adapter: node(),
 
-    // hydrate the <div id="svelte"> element in src/app.html
-    target: '#svelte',
-
     vite: {
       server: {
         hmr: {


### PR DESCRIPTION
…removed